### PR TITLE
Updated nose requirement in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ unittest2>=0.5.1
 interruptingcow>=0.6
 
 # Nose is used as top level test driver and reporting.
-nose2>=0.4.6
+nose>=1.3.1
 
 # DDT module for Data driven decorators. (we extend these for our ddt decorators)
 ddt>=0.2.0


### PR DESCRIPTION
On Windows, the version of nose included in the requirements does not install nosetests-2.7.exe by default. I tested on OSX and the current nose version worked fine so it seems to be a Windows-specific issue. After I installed nose==1.3.1, I was able to use runtests.py.

Powershell output during install with nose2>=0.4.7:

```
PS C:\TestProject> pip install wtframework
Downloading/unpacking wtframework
  Running setup.py egg_info for package wtframework

Downloading/unpacking nose2>=0.4.7 (from wtframework)
  Running setup.py egg_info for package nose2

Installing collected packages: wtframework, nose2
  Running setup.py install for wtframework

  Running setup.py install for nose2

    warning: no previously-included files matching '__pycache__' found anywhere in distribution
    warning: no previously-included files matching '*~' found anywhere in distribution
    warning: no previously-included files matching '*.pyc' found anywhere in distribution
    Installing nose2-2.7-script.py script to C:\Python27\Scripts
    Installing nose2-2.7.exe script to C:\Python27\Scripts
    Installing nose2-2.7.exe.manifest script to C:\Python27\Scripts
    Installing nose2-script.py script to C:\Python27\Scripts
    Installing nose2.exe script to C:\Python27\Scripts
    Installing nose2.exe.manifest script to C:\Python27\Scripts
Successfully installed wtframework nose2
Cleaning up...
PS C:\TestProject> python .\runtests.py
'nosetests-2.7' is not recognized as an internal or external command,
operable program or batch file.
```
